### PR TITLE
[Yuto] The Hack チャレンジ 2023年4月 問題

### DIFF
--- a/2023-Apr-07/prisma/schema.prisma
+++ b/2023-Apr-07/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["clientExtensions"]
 }
 
 datasource db {

--- a/2023-Apr-07/src/functions/hello/handler.ts
+++ b/2023-Apr-07/src/functions/hello/handler.ts
@@ -1,7 +1,7 @@
 import type { ValidatedEventAPIGatewayProxyEvent } from '@libs/api-gateway';
 import { formatJSONResponse } from '@libs/api-gateway';
 import { middyfy } from '@libs/lambda';
-import { PrismaClient, Author, Post } from "@prisma/client";
+import { PrismaClient, Author, Post, Prisma } from "@prisma/client";
 
 import schema from './schema';
 
@@ -9,11 +9,34 @@ export const prisma = new PrismaClient({
   log: ['query', 'info', 'warn', 'error'],
 })
 
-const hello: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) => {
+// Prisma Client extensions で、独自のモデルメソッドを定義
+const xprisma = prisma.$extends({
+  model: {
+    $allModels: {
+      loadChildren<T, A>(
+        this: T,
+        models: { id: number }[],
+        args: Prisma.Exact<A, Prisma.Args<T, "findMany">> & object
+      ): Prisma.Result<T, A, "findMany"> {
+        return (this as any).findMany({
+          where: {
+            id: { in: models.map((model) => model.id) },
+          },
+          ...args,
+        });
+      },
+    },
+  },
+});
 
+const hello: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) => {
   const authors = await prisma.$queryRaw`select * from Author` as Array<Author>;
 
-  const authorsWithChildren: Array<Author & { posts: Post[] }> = loadChildren(authors)
+  const authorsWithChildren = await xprisma.author.loadChildren(authors, {
+    include: {
+      posts: true,
+    }
+  })
 
   // 問題1: 上記で返る型を下記と同じにしたい（あくまで例なので、loadChildren の入力は汎用的でないといけない）
   const authorsWithChildren2 = await prisma.author.findMany({
@@ -23,7 +46,15 @@ const hello: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) =
   })
 
   // 問題2: (問題1の発展) 下記 3と4が同じ型になるようにしたい。
-  const authorsWithChildren3: Array<Author & { posts: Post[] }> = loadChildrenWithCustomizedFetch(authors)
+  const authorsWithChildren3 = await xprisma.author.loadChildren(authors, {
+    include: {
+      posts: {
+        include: {
+          children: true
+        }
+      },
+    }
+  })
 
   // TODO: 上記で返る型を下記と同じにしたい
   const authorsWithChildren4 = await prisma.author.findMany({
@@ -48,21 +79,6 @@ const hello: ValidatedEventAPIGatewayProxyEvent<typeof schema> = async (event) =
     event,
   });
 };
-
-// 下記関数の引数から考えてください。今は仮で Array<any> の target 変数を入れています。
-function loadChildren(target: Array<any>) {
-  // TODO: 任意の子供を付与して、子供の配列をパラメータとして追加された型を返す
-  // targetの入力は、任意のPrismaのモデルの配列となるようにして、汎用性をもたせる
-}
-
-function loadChildrenWithCustomizedFetch(target: Array<any>) {
-  // TODO: 任意の子供とそれに追加で OptionのObjectを指定する（ただし、型を他の入力から解決する必要あり）ことで、孫などを含めてロード可能にする
-  // 例えば
-  // loadChildrenWithCustomizedFetch(authors, 'posts', { include: { children: true } });
-  // のような入力で、 Array<Author & { posts: Array<Post & { children: PostChild[] }> }>
-  // のような型が返るようにする。（関数の引数の型定義はあくまで例なので自由に考えてください）
-  // targetの入力は、任意のPrismaのモデルの配列となるようにして、汎用性をもたせる
-}
 
 
 export const main = middyfy(hello);


### PR DESCRIPTION
schema.prisma ファイルを編集したので migrate が必要だと思います。
普通に関数を実装しようとしても、うまく型をつける方法が思いつかなかったので、
下記の方法でモデルを拡張して独自メソッドを定義するのがいいのではないかと考えました。
https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions/model#advanced-type-safety-improve-the-type-safety-and-developer-experience-of-your-custom-model-methods

こういう記事も参考にしました。
https://zenn.dev/gibjapan/articles/815c0a6783d5ff